### PR TITLE
Replace ceil_mode with round_mode

### DIFF
--- a/DenseNet_121.prototxt
+++ b/DenseNet_121.prototxt
@@ -51,7 +51,7 @@ layer {
     kernel_size: 3
     stride: 2
     pad: 1
-    ceil_mode: false
+    round_mode: FLOOR
   }
 }
 layer {

--- a/DenseNet_161.prototxt
+++ b/DenseNet_161.prototxt
@@ -51,7 +51,7 @@ layer {
     kernel_size: 3
     stride: 2
     pad: 1
-    ceil_mode: false
+    round_mode: FLOOR
   }
 }
 layer {

--- a/DenseNet_169.prototxt
+++ b/DenseNet_169.prototxt
@@ -51,7 +51,7 @@ layer {
     kernel_size: 3
     stride: 2
     pad: 1
-    ceil_mode: false
+    round_mode: FLOOR
   }
 }
 layer {

--- a/DenseNet_201.prototxt
+++ b/DenseNet_201.prototxt
@@ -51,7 +51,7 @@ layer {
     kernel_size: 3
     stride: 2
     pad: 1
-    ceil_mode: false
+    round_mode: FLOOR
   }
 }
 layer {

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ DenseNet 161 (k=48)| 77.64| 93.79| [caffemodel (110 MB)](https://drive.google.co
 Due to compatibility reasons, several modifications have been made:
 - BGR mean values **[103.94,116.78,123.68]** are subtracted
 - **scale: 0.017** is used, instead of the original std values for image preprocessing
-- **ceil_mode: false** is used in the first pooling layers ('pool1') 
+- **round_mode: FLOOR** is used in the first pooling layers ('pool1')


### PR DESCRIPTION
The param ceil_mode was proposed in https://github.com/BVLC/caffe/pull/3057 , but never merged. Its replacement, https://github.com/BVLC/caffe/pull/6282 , fulfills the same need with some syntactic variance. The param is now called "round_mode" and it is an enum, instead of a boolean. This commit modifies the files accordingly.

This will allow usage of the models without having to modify Caffe code, addressing https://github.com/shicai/DenseNet-Caffe/issues/1,  https://github.com/shicai/DenseNet-Caffe/issues/6, as well as averting issues like https://github.com/shicai/DenseNet-Caffe/issues/15.